### PR TITLE
Jib 인증 수정

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -36,10 +36,11 @@ jobs:
 
       - name: Build and Push with Jib
         run: |
+          echo "${{ secrets.GCP_SA_KEY }}" > gcp-key.json
           ./gradlew jib \
             -Djib.to.image=gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA \
             -Djib.to.auth.username=_json_key \
-            -Djib.to.auth.password='${{ secrets.GCP_SA_KEY }}'
+            -Djib.to.auth.password="$(cat gcp-key.json)"
 
       - name: Deploy to Cloud Run
         run: |


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #5 #11 

## 📝작업 내용

> deploy Jib 인증 오류를 해결합니다.
GCP_SA_KEY가 JSON 형식이라, ' ' 작은따옴표로 감싸면 내부 줄바꿈(\n)이 그대로 들어가서 잘못된 비밀번호로 인식돼 Jib이 인증 실패를 일으킵니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
