### PR TITLE
[Feat] 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/example/oauth2prac/controller/TokenController.java
+++ b/src/main/java/com/example/oauth2prac/controller/TokenController.java
@@ -1,11 +1,17 @@
 package com.example.oauth2prac.controller;
 
+import com.example.oauth2prac.config.SecurityUtils;
 import com.example.oauth2prac.dto.TokenRefreshRequestDto;
 import com.example.oauth2prac.dto.TokenRefreshResponseDto;
 import com.example.oauth2prac.entity.JwtTokenProvider;
 import com.example.oauth2prac.entity.User;
 import com.example.oauth2prac.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -31,5 +37,40 @@ public class TokenController {
         User user = userRepository.findByRefreshToken(requestDto.getRefreshToken()).orElseThrow();
         String newAccessToken = jwtTokenProvider.reissue(requestDto.getRefreshToken());
         return new TokenRefreshResponseDto(newAccessToken);
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            Long userId = SecurityUtils.currentUserIdOrThrow();
+            
+            // refreshToken 삭제
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+            user.updateRefreshToken(null);
+            userRepository.save(user);
+            
+            // accessToken 쿠키 삭제
+            Cookie cookie = new Cookie("accessToken", null);
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
+            
+            // SecurityContext 클리어 -> 인증정보 제거
+            SecurityContextHolder.clearContext();
+            
+            return ResponseEntity.ok().build();
+        } catch (IllegalStateException e) {
+            // 이미 로그아웃된 상태 -> 쿠키만 삭제
+            Cookie cookie = new Cookie("accessToken", null);
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+            cookie.setMaxAge(0);
+            response.addCookie(cookie);
+            
+            return ResponseEntity.ok().build();
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #7 

## 📝작업 내용

> POST /api/token/logout API 추가

현재 로그인한 사용자의 refreshToken을 DB에서 제거

accessToken 쿠키를 만료시켜 브라우저 측 인증 제거

SecurityContextHolder.clearContext()를 통해 인증 정보 초기화

이미 로그아웃된 상태(IllegalStateException)에서도 쿠키 제거만 수행하도록 예외 처리

인증정보와 토큰을 모두 정리하여 완전한 로그아웃 상태 보장

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
