### PR TITLE
[Feat] 로그인 SecuriyConfig 통합 -> 수동 API 변경

### DIFF
--- a/src/main/java/com/example/oauth2prac/config/SecurityConfig.java
+++ b/src/main/java/com/example/oauth2prac/config/SecurityConfig.java
@@ -1,23 +1,16 @@
 package com.example.oauth2prac.config;
 
-import com.example.oauth2prac.config.oauth2.OAuthAttributes;
-import com.example.oauth2prac.entity.*;
 import com.example.oauth2prac.repository.UserRepository;
-import com.example.oauth2prac.service.CustomOAuth2UserService;
-import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,18 +20,13 @@ import java.util.List;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final CustomOAuth2UserService customOAuth2UserService;
-    private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-
                 .csrf(csrf -> csrf.disable())
-
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/",
@@ -51,87 +39,33 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**",
                                 "/api/token/**",
+                                "/api/oauth/**", // OAuth2 로그인 API 경로 허용
                                 "/favicon.ico"
                         ).permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated()
                 )
-
-                .logout(logout -> logout.logoutSuccessUrl("/"))
-
-                .oauth2Login(oauth -> oauth
-                        .loginPage("/")
-                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
-                        .successHandler((request, response, authentication) -> {
-                            OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
-                            String registrationId = ((OAuth2AuthenticationToken) authentication)
-                                    .getAuthorizedClientRegistrationId();
-
-                            OAuthAttributes attributes = OAuthAttributes.of(
-                                    registrationId,
-                                    "sub",
-                                    oAuth2User.getAttributes()
-                            );
-
-                            User user = userRepository.findByEmail(attributes.getEmail())
-                                    .orElseThrow(() -> new IllegalArgumentException("해당 이메일이 존재하지 않습니다."));
-
-                            String token = jwtTokenProvider.createToken(
-                                    user.getId().toString(),
-                                    user.getRoleKey()
-                            );
-                            String refreshToken = jwtTokenProvider.createRefreshToken(
-                                    user.getId().toString()
-                            );
-
-                            String oauthId = attributes.getNameAttributeKey();
-                            if (oauthId.equals("id")) {
-                                oauthId = "kakao";
-                            } else {
-                                oauthId = "Google";
-                            }
-
-                            user.setOauthId(oauthId);
-                            user.updateRefreshToken(refreshToken);
-                            userRepository.save(user);
-
-                            String frontendUrl = "http://{프론트엔드_주소}/oauth/callback"; // 실제 프론트엔드 주소로 변경해야 합니다.
-
-                            String redirectUrl = UriComponentsBuilder.fromUriString(frontendUrl)
-                                    .queryParam("accessToken", token)
-                                    .queryParam("refreshToken", refreshToken)
-                                    .build().toUriString();
-
-                            response.sendRedirect(redirectUrl);
-                        })
-                );
+                .logout(logout -> logout.logoutSuccessUrl("/"));
 
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
-    // CORS 설정을 Bean으로 정의
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-
-        // 모든 origin 허용 (Swagger UI 및 브라우저 직접 호출 지원)
         configuration.setAllowedOriginPatterns(Arrays.asList("*"));
         configuration.setAllowedMethods(Arrays.asList(
                 "GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"
         ));
-
         configuration.setAllowedHeaders(List.of("*"));
-
         configuration.setExposedHeaders(Arrays.asList(
                 "Authorization",
                 "Content-Type",
                 "X-Total-Count"
         ));
-
-        configuration.setAllowCredentials(false);
-
+        configuration.setAllowCredentials(true); // credentials 허용
         configuration.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/example/oauth2prac/controller/OAuthController.java
+++ b/src/main/java/com/example/oauth2prac/controller/OAuthController.java
@@ -1,0 +1,27 @@
+package com.example.oauth2prac.controller;
+
+import com.example.oauth2prac.dto.LoginResponseDto;
+import com.example.oauth2prac.service.OAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth")
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @Operation(summary = "카카오 로그인 콜백", description = "카카오로부터 인가 코드를 받아 로그인을 처리합니다.")
+    @GetMapping("/kakao/callback")
+    public Mono<ResponseEntity<LoginResponseDto>> kakaoCallback(@RequestParam("code") String code) {
+        return oAuthService.loginWithKakao(code)
+                .map(ResponseEntity::ok);
+    }
+}

--- a/src/main/java/com/example/oauth2prac/dto/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/example/oauth2prac/dto/KakaoUserInfoResponseDto.java
@@ -1,0 +1,36 @@
+package com.example.oauth2prac.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoResponseDto {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("properties")
+    private KakaoProperties properties;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoProperties {
+        @JsonProperty("nickname")
+        private String nickname;
+
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        @JsonProperty("email")
+        private String email;
+    }
+}

--- a/src/main/java/com/example/oauth2prac/dto/LoginResponseDto.java
+++ b/src/main/java/com/example/oauth2prac/dto/LoginResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.oauth2prac.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponseDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/oauth2prac/service/OAuthService.java
+++ b/src/main/java/com/example/oauth2prac/service/OAuthService.java
@@ -1,0 +1,108 @@
+package com.example.oauth2prac.service;
+
+import com.example.oauth2prac.dto.KakaoUserInfoResponseDto;
+import com.example.oauth2prac.dto.LoginResponseDto;
+import com.example.oauth2prac.entity.JwtTokenProvider;
+import com.example.oauth2prac.entity.Role;
+import com.example.oauth2prac.entity.User;
+import com.example.oauth2prac.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final WebClient webClient;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String kakaoTokenUri;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String kakaoUserInfoUri;
+
+    @Transactional
+    public Mono<LoginResponseDto> loginWithKakao(String code) {
+        return getKakaoAccessToken(code)
+                .flatMap(this::getKakaoUserInfo)
+                .flatMap(this::saveOrUpdateUser)
+                .map(this::generateTokens);
+    }
+
+    private Mono<String> getKakaoAccessToken(String code) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("client_id", kakaoClientId);
+        formData.add("redirect_uri", kakaoRedirectUri);
+        formData.add("code", code);
+
+        return webClient.post()
+                .uri(kakaoTokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .bodyValue(formData)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .map(response -> (String) response.get("access_token"));
+    }
+
+    private Mono<KakaoUserInfoResponseDto> getKakaoUserInfo(String accessToken) {
+        return webClient.get()
+                .uri(kakaoUserInfoUri)
+                .headers(headers -> headers.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(KakaoUserInfoResponseDto.class);
+    }
+
+    private Mono<User> saveOrUpdateUser(KakaoUserInfoResponseDto userInfo) {
+        String email = userInfo.getKakaoAccount().getEmail();
+        String nickname = userInfo.getProperties().getNickname();
+        String profileImage = userInfo.getProperties().getProfileImageUrl();
+
+        return Mono.fromCallable(() -> userRepository.findByEmail(email)
+                .map(user -> {
+                    log.info("Existing user found: {}", user.getEmail());
+                    // Optionally update user info here if needed
+                    return user;
+                })
+                .orElseGet(() -> {
+                    log.info("New user, creating and saving: {}", email);
+                    User newUser = User.builder()
+                            .email(email)
+                            .name(nickname)
+                            .picture(profileImage)
+                            .role(Role.USER)
+                            .build();
+                    return userRepository.save(newUser);
+                })).subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic());
+    }
+
+    private LoginResponseDto generateTokens(User user) {
+        String accessToken = jwtTokenProvider.createToken(user.getId().toString(), user.getRoleKey());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId().toString());
+        user.updateRefreshToken(refreshToken);
+        userRepository.save(user);
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ spring:
             client-secret: ${KAKAO_CLIENT_SECRET}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
-            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            redirect-uri: "{baseUrl}/api/oauth/kakao/callback"
             scope:
               - profile_nickname
               - account_email


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #7 

## 📝작업 내용

기존 Spring Security의 통합 OAuth2 로그인 방식(.oauth2Login())을 수동 API 호출 방식으로 전면 리팩토링했습니다. 이를 통해 프론트엔드와의 역할 분담을 명확히 하고, 보다 직관적인 데이터(JSON) 기반으로 통신하도록 구조를 개선했습니다.

1. 인증 흐름 변경:◦(AS-IS): 프론트엔드가 백엔드의 특정 경로(oauth2/authorization/kakao)를 호출하면, 백엔드가 모든 과정을 처리 후 프론트엔드 URL로 토큰을 담아 리디렉션했습니다.◦(TO-BE): 프론트엔드가 카카오 로그인 후 받은 인가 코드를 백엔드의 새로운 API(GET /api/oauth/kakao/callback)로 전송하면, 백엔드는 JSON 형태의 JWT 토큰을 직접 응답합니다.
2. OAuthController, OAuthService 신설: 카카오 로그인 콜백을 처리하고, 인가 코드를 받아 카카오 API와 직접 통신하여 우리 서비스의 JWT를 발급하는 로직을 OAuthService에 구현했습니다.
3. WebClient를 이용한 외부 API 통신:◦OAuthService 내에서 WebClient를 사용하여 카카오 서버에 토큰 발급 및 사용자 정보 조회를 요청하는 로직을 구현했습니다.
4. 타입 안정성 강화 (KakaoUserInfoResponseDto 도입): 카카오 사용자 정보를 파싱할 때, 기존의 불안정한 Map<String, Object> 방식 대신 전용 DTO(KakaoUserInfoResponseDto)를 생성하여 사용하도록 개선했습니다. 이를 통해 bodyToMono에서 발생하던 타입 관련 문제를 해결하고, 코드의 안정성과 가독성을 크게 향상시켰습니다.
5. 기존 .oauth2Login() 관련 설정을 모두 제거했습니다. 새로 만든 API 엔드포인트(api/oauth/**)에 대한 접근을 허용하도록 SecurityConfig를 수정했습니다. 카카오에 등록할 redirect-uri를 새로운 API 콜백 주소로 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Kakao 소셜 로그인 통합 완료
  * OAuth 콜백 엔드포인트 추가

* **보안 개선**
  * 보안 설정 간소화 및 최적화
  * JWT 토큰 기반 인증 강화
  * CORS 정책 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->