### PR TITLE
[Feat] 이미지 분석 처리 최적화

### DIFF
--- a/src/main/java/com/example/oauth2prac/domain/segmentedImage/ImageAnalysisController.java
+++ b/src/main/java/com/example/oauth2prac/domain/segmentedImage/ImageAnalysisController.java
@@ -13,10 +13,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.Exceptions;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -24,6 +26,9 @@ import java.util.List;
 @RequestMapping("/api/images")
 @RequiredArgsConstructor
 public class ImageAnalysisController {
+
+    private static final int MAX_IMAGE_COUNT = 10;
+    private static final int IMAGE_PROCESSING_CONCURRENCY = 3;
 
     private final GCSUploadService gcsUploadService;
     private final ImageProcessingService imageProcessingService;
@@ -41,36 +46,28 @@ public class ImageAnalysisController {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-            // 2. 이미지를 S3에 업로드하고 URL을 받음
-            log.info("Uploading image to S3: {}", image.getOriginalFilename());
-            String imageUrl = gcsUploadService.upload(image);
+            // 2. 이미지를 GCS에 업로드하고 원본 이미지 정보를 DB에 저장
+            OriginalImage originalImage = uploadAndSaveOriginalImage(image, user);
 
-            // 3. 원본 이미지 정보를 DB에 저장
-            OriginalImage originalImage = OriginalImage.builder()
-                    .user(user)
-                    .imageUrl(imageUrl)
-                    .fileName(image.getOriginalFilename())
-                    .build();
-            originalImageRepository.save(originalImage);
-            log.info("Original image saved with ID: {}", originalImage.getId());
-
-            // 4. FastAPI에 분석 요청 보내고 결과를 받음
+            // 3. FastAPI에 분석 요청 보내고 결과를 받음
             SegmentationResponseDTO analysisResult = imageProcessingService
                     .requestSegmentation(originalImage)
                     .block();
 
-            // 5. 클라이언트에 최종 결과 반환
+            // 4. 클라이언트에 최종 결과 반환
             return ResponseEntity.ok(analysisResult);
 
-        } catch (IOException e) {
-            log.error("이미지 업로드 중 오류 발생: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("이미지 업로드에 실패했습니다: " + e.getMessage());
         } catch (IllegalArgumentException e) {
             log.error("잘못된 요청: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(e.getMessage());
         } catch (Exception e) {
+            Throwable cause = Exceptions.unwrap(e);
+            if (cause instanceof IOException) {
+                log.error("이미지 업로드 중 오류 발생: {}", cause.getMessage(), cause);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body("이미지 업로드에 실패했습니다: " + cause.getMessage());
+            }
             log.error("이미지 분석 중 오류 발생: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body("이미지 분석에 실패했습니다: " + e.getMessage());
@@ -88,32 +85,18 @@ public class ImageAnalysisController {
                     .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
             // 이미지 개수 제한
-            if (images.size() > 10) {
+            if (images.size() > MAX_IMAGE_COUNT) {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                        .body("한 번에 최대 10개의 이미지만 처리할 수 있습니다.");
+                        .body("한 번에 최대 " + MAX_IMAGE_COUNT + "개의 이미지만 처리할 수 있습니다.");
             }
 
             log.info("Processing {} images for user {}", images.size(), userId);
 
-            List<OriginalImage> originalImages = new ArrayList<>();
-
-            for (MultipartFile image : images) {
-                log.info("Uploading image to S3: {}", image.getOriginalFilename());
-                String imageUrl = gcsUploadService.upload(image);
-
-                OriginalImage originalImage = OriginalImage.builder()
-                        .user(user)
-                        .imageUrl(imageUrl)
-                        .fileName(image.getOriginalFilename())
-                        .build();
-                originalImageRepository.save(originalImage);
-                originalImages.add(originalImage);
-                log.info("Original image saved with ID: {}", originalImage.getId());
-            }
-
-            // Reactor Flux 비동기 병렬 처리
-            List<SegmentationResponseDTO> results = Flux.fromIterable(originalImages)
-                    .flatMap(originalImage -> imageProcessingService.requestSegmentation(originalImage))
+            List<SegmentationResponseDTO> results = Flux.fromIterable(images)
+                    .flatMapSequential(image -> Mono.fromCallable(() -> uploadAndSaveOriginalImage(image, user))
+                                    .subscribeOn(Schedulers.boundedElastic())
+                                    .flatMap(imageProcessingService::requestSegmentation),
+                            IMAGE_PROCESSING_CONCURRENCY)
                     .collectList()
                     .block();
 
@@ -124,18 +107,35 @@ public class ImageAnalysisController {
 
             return ResponseEntity.ok(response);
 
-        } catch (IOException e) {
-            log.error("이미지 업로드 중 오류 발생: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("이미지 업로드에 실패했습니다: " + e.getMessage());
         } catch (IllegalArgumentException e) {
             log.error("잘못된 요청: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(e.getMessage());
         } catch (Exception e) {
+            Throwable cause = Exceptions.unwrap(e);
+            if (cause instanceof IOException) {
+                log.error("이미지 업로드 중 오류 발생: {}", cause.getMessage(), cause);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body("이미지 업로드에 실패했습니다: " + cause.getMessage());
+            }
             log.error("이미지 분석 중 오류 발생: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body("이미지 분석에 실패했습니다: " + e.getMessage());
         }
+    }
+
+    private OriginalImage uploadAndSaveOriginalImage(MultipartFile image, User user) throws IOException {
+        log.info("Uploading image to GCS: {}", image.getOriginalFilename());
+        String imageUrl = gcsUploadService.upload(image);
+
+        OriginalImage originalImage = OriginalImage.builder()
+                .user(user)
+                .imageUrl(imageUrl)
+                .fileName(image.getOriginalFilename())
+                .build();
+        originalImageRepository.save(originalImage);
+        log.info("Original image saved with ID: {}", originalImage.getId());
+
+        return originalImage;
     }
 }

--- a/src/main/java/com/example/oauth2prac/global/gcs/GCSUploadService.java
+++ b/src/main/java/com/example/oauth2prac/global/gcs/GCSUploadService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.UUID;
 
 @Slf4j
@@ -39,11 +40,9 @@ public class GCSUploadService {
                 .setContentType(multipartFile.getContentType())
                 .build();
 
-        // 파일 업로드
-        Blob blob = storage.create(
-                blobInfo,
-                multipartFile.getBytes()
-        );
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            storage.createFrom(blobInfo, inputStream);
+        }
 
         log.info("File uploaded to GCS: {}", fileName);
 


### PR DESCRIPTION
 ## #️⃣연관된 이슈

  > #25 

  ## 📝작업 내용

  - 이미지 분석 처리 시간 최적화
  - GCS 업로드 시 `getBytes()` 대신 `InputStream` 기반 스트리밍 업로드로 변경
  - 여러 장 이미지 분석 시 업로드, DB 저장, FastAPI 분석 흐름을 이미지별 병렬 처리하도록 개선
  - 동시 처리 개수를 3개로 제한하여 FastAPI/GCS 부하를 제어
  - 단일/다중 이미지 업로드 및 원본 이미지 저장 로직 공통화

  ### 스크린샷 (선택)

  없음

  ## 💬리뷰 요구사항(선택)

  - 다중 이미지 분석 동시 처리 개수 `3`이 현재 FastAPI 서버 성능 기준에서 적절한지 확인 부탁드립니다.
  - GCS 스트리밍 업로드 방식이 기존 업로드 동작과 동일하게 동작하는지 확인 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 이미지 분석에 동시 처리 지원으로 성능 개선
  * 파일 업로드 시 스트리밍 방식 적용으로 메모리 사용량 최적화
  * 파일 업로드 오류 처리 및 메시지 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-gyeol/Gyeol-Server/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->