### PR TITLE
[Fix] 이미지 분석 실패 시 원본 정리

### DIFF
--- a/src/main/java/com/example/oauth2prac/domain/segmentedImage/ImageAnalysisController.java
+++ b/src/main/java/com/example/oauth2prac/domain/segmentedImage/ImageAnalysisController.java
@@ -40,6 +40,7 @@ public class ImageAnalysisController {
     public ResponseEntity<?> analyzeImage(
             @RequestPart(value = "image") MultipartFile image) {
 
+        OriginalImage originalImage = null;
         try {
             // 1. 사용자 정보 조회
             Long userId = SecurityUtils.currentUserIdOrThrow();
@@ -47,7 +48,7 @@ public class ImageAnalysisController {
                     .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
             // 2. 이미지를 GCS에 업로드하고 원본 이미지 정보를 DB에 저장
-            OriginalImage originalImage = uploadAndSaveOriginalImage(image, user);
+            originalImage = uploadAndSaveOriginalImage(image, user);
 
             // 3. FastAPI에 분석 요청 보내고 결과를 받음
             SegmentationResponseDTO analysisResult = imageProcessingService
@@ -62,6 +63,7 @@ public class ImageAnalysisController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(e.getMessage());
         } catch (Exception e) {
+            cleanupOriginalImage(originalImage);
             Throwable cause = Exceptions.unwrap(e);
             if (cause instanceof IOException) {
                 log.error("이미지 업로드 중 오류 발생: {}", cause.getMessage(), cause);
@@ -95,7 +97,8 @@ public class ImageAnalysisController {
             List<SegmentationResponseDTO> results = Flux.fromIterable(images)
                     .flatMapSequential(image -> Mono.fromCallable(() -> uploadAndSaveOriginalImage(image, user))
                                     .subscribeOn(Schedulers.boundedElastic())
-                                    .flatMap(imageProcessingService::requestSegmentation),
+                                    .flatMap(originalImage -> imageProcessingService.requestSegmentation(originalImage)
+                                            .doOnError(error -> cleanupOriginalImage(originalImage))),
                             IMAGE_PROCESSING_CONCURRENCY)
                     .collectList()
                     .block();
@@ -137,5 +140,19 @@ public class ImageAnalysisController {
         log.info("Original image saved with ID: {}", originalImage.getId());
 
         return originalImage;
+    }
+
+    private void cleanupOriginalImage(OriginalImage originalImage) {
+        if (originalImage == null) {
+            return;
+        }
+
+        try {
+            log.info("Cleaning up original image after failed analysis: {}", originalImage.getImageUrl());
+            gcsUploadService.deleteByUrl(originalImage.getImageUrl());
+            originalImageRepository.delete(originalImage);
+        } catch (Exception cleanupError) {
+            log.warn("원본 이미지 정리 중 오류 발생: {}", cleanupError.getMessage(), cleanupError);
+        }
     }
 }

--- a/src/main/java/com/example/oauth2prac/domain/segmentedImage/ImageProcessingService.java
+++ b/src/main/java/com/example/oauth2prac/domain/segmentedImage/ImageProcessingService.java
@@ -52,6 +52,11 @@ public class ImageProcessingService {
                     log.info("Segmentation result saved successfully for image ID: {}", originalImage.getId());
 
                     return Mono.just(responseDto);
-                });
+                })
+                .doOnError(error -> log.warn(
+                        "Segmentation failed for original image ID {}: {}",
+                        originalImage.getId(),
+                        error.getMessage()
+                ));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #53 

## 📝작업 내용

- 이미지 분석 실패 시 업로드된 원본 이미지를 GCS에서 정리하도록 처리했습니다.
- 단일 이미지 분석 실패 시 `OriginalImage` DB 레코드도 함께 삭제되도록 보완했습니다.
- 다중 이미지 분석에서도 개별 이미지 분석 실패 시 해당 원본 이미지가 버킷에 남지 않도록 정리 로직을 추가했습니다.
- 이미지 분석 실패 로그를 추가해 원인 확인이 쉽도록 했습니다.

### 스크린샷 (선택)

없음

## 💬리뷰 요구사항(선택)

- 분석 실패 시 원본 이미지와 DB 레코드 정리 흐름이 적절한지 확인 부탁드립니다.
- 다중 이미지 분석 중 일부 실패가 발생했을 때 현재처럼 전체 요청을 실패 처리하는 흐름이 괜찮은지 봐주시면 좋겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
  * 이미지 분석 실패 시 저장된 이미지가 자동으로 정리되어 저장 공간 낭비가 방지됩니다.
  * 오류 발생 시 상세한 로그 정보가 기록되어 문제 진단이 개선됩니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-gyeol/Gyeol-Server/pull/54)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->